### PR TITLE
 Submit logic for player statlines

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,13 @@
     "lucide-react": "^0.507.0",
     "next": "^15.2.3",
     "next-auth": "5.0.0-beta.25",
+    "nuqs": "^2.4.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.56.1",
     "server-only": "^0.0.1",
     "superjson": "^2.2.1",
-    "tailwind-merge": "^3.0.2",
+    "tailwind-merge": "^3.2.0",
     "zod": "^3.24.2",
     "zustand": "^5.0.4"
   },
@@ -64,6 +65,7 @@
     "prettier-plugin-tailwindcss": "^0.6.11",
     "prisma": "^6.5.0",
     "tailwindcss": "^4.0.15",
+    "tw-animate-css": "^1.2.9",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.27.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ dependencies:
   next-auth:
     specifier: 5.0.0-beta.25
     version: 5.0.0-beta.25(next@15.3.1)(react@19.1.0)
+  nuqs:
+    specifier: ^2.4.3
+    version: 2.4.3(next@15.3.1)(react@19.1.0)
   react:
     specifier: ^19.0.0
     version: 19.1.0
@@ -78,7 +81,7 @@ dependencies:
     specifier: ^2.2.1
     version: 2.2.2
   tailwind-merge:
-    specifier: ^3.0.2
+    specifier: ^3.2.0
     version: 3.2.0
   zod:
     specifier: ^3.24.2
@@ -130,6 +133,9 @@ devDependencies:
   tailwindcss:
     specifier: ^4.0.15
     version: 4.1.4
+  tw-animate-css:
+    specifier: ^1.2.9
+    version: 1.2.9
   typescript:
     specifier: ^5.8.2
     version: 5.8.3
@@ -3627,6 +3633,10 @@ packages:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: true
 
+  /mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+    dev: false
+
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -3709,6 +3719,29 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+    dev: false
+
+  /nuqs@2.4.3(next@15.3.1)(react@19.1.0):
+    resolution: {integrity: sha512-BgtlYpvRwLYiJuWzxt34q2bXu/AIS66sLU1QePIMr2LWkb+XH0vKXdbLSgn9t6p7QKzwI7f38rX3Wl9llTXQ8Q==}
+    peerDependencies:
+      '@remix-run/react': '>=2'
+      next: '>=14.2.0'
+      react: '>=18.2.0 || ^19.0.0-0'
+      react-router: ^6 || ^7
+      react-router-dom: ^6 || ^7
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      next:
+        optional: true
+      react-router:
+        optional: true
+      react-router-dom:
+        optional: true
+    dependencies:
+      mitt: 3.0.1
+      next: 15.3.1(react-dom@19.1.0)(react@19.1.0)
+      react: 19.1.0
     dev: false
 
   /oauth4webapi@3.5.0:
@@ -4493,6 +4526,10 @@ packages:
 
   /tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  /tw-animate-css@1.2.9:
+    resolution: {integrity: sha512-9O4k1at9pMQff9EAcCEuy1UNO43JmaPQvq+0lwza9Y0BQ6LB38NiMj+qHqjoQf40355MX+gs6wtlR6H9WsSXFg==}
+    dev: true
 
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -129,7 +129,6 @@ model Activity {
 // Statline table
 model Statline {
   id                 String      @id @default(cuid())
-  playerId           String
   teamMemberId       String
   fieldGoalsMade     Int
   fieldGoalsMissed   Int

--- a/src/features/schedule/lib/search-params.tsx
+++ b/src/features/schedule/lib/search-params.tsx
@@ -1,0 +1,9 @@
+import { createSearchParamsCache, parseAsString } from "nuqs/server";
+
+export const boxScoreSearchParams = {
+  activityId: parseAsString.withDefault(""),
+  teamId: parseAsString.withDefault(""),
+};
+
+export const boxScoreSearchParamsCache =
+  createSearchParamsCache(boxScoreSearchParams);

--- a/src/features/scouting/components/player-stat-row.tsx
+++ b/src/features/scouting/components/player-stat-row.tsx
@@ -19,26 +19,16 @@ export const PlayerStatsRow = ({
   activePlayerIndex,
   setActivePlayerIndex,
 }: PlayerStatsRowProps) => {
-  const { fieldGoals, freeThrows, threePointers, totalPoints } = calculateStats(
-    {
-      fieldGoalsMade: statsForPlayer.fieldGoalsMade ?? 0,
-      fieldGoalsMissed: statsForPlayer.fieldGoalsMissed ?? 0,
-      threePointersMade: statsForPlayer.threePointersMade ?? 0,
-      threePointersMissed: statsForPlayer.threePointersMissed ?? 0,
-      freeThrows: statsForPlayer.freeThrows ?? 0,
-      missedFreeThrows: statsForPlayer.missedFreeThrows ?? 0,
-      assists: statsForPlayer.assists ?? 0,
-      steals: statsForPlayer.steals ?? 0,
-      turnovers: statsForPlayer.turnovers ?? 0,
-      rebounds: statsForPlayer.rebounds ?? 0,
-      blocks: statsForPlayer.blocks ?? 0,
-    },
-  );
+  const { fieldGoals, freeThrows, threePointers, totalPoints } =
+    calculateStats(statsForPlayer);
 
   return (
     <TableRow>
       <TableCell className="p-3 text-left font-medium dark:text-white">
         {player.name}
+      </TableCell>
+      <TableCell className="p-3 text-center align-middle dark:text-gray-300">
+        {totalPoints}
       </TableCell>
       <TableCell className="p-3 text-center align-middle dark:text-gray-300">
         {fieldGoals.made}/{fieldGoals.attempted}
@@ -64,12 +54,11 @@ export const PlayerStatsRow = ({
       <TableCell className="p-3 text-center align-middle dark:text-gray-300">
         {statsForPlayer?.turnovers ?? 0}
       </TableCell>
-      <TableCell className="p-3 text-center align-middle dark:text-gray-300">
-        {totalPoints}
-      </TableCell>
+
       <TableCell className="p-3 text-center align-middle">
         <Button
-          variant={index === activePlayerIndex ? "default" : "outline"}
+          type="button"
+          variant={index === activePlayerIndex ? "danger" : "outline"}
           onClick={() => setActivePlayerIndex(index)}
           size="sm"
         >

--- a/src/features/scouting/components/team-stats-row.tsx
+++ b/src/features/scouting/components/team-stats-row.tsx
@@ -1,0 +1,46 @@
+import { TableCell } from "@/components/ui/table";
+import { calculateTeamStats } from "../utils/update-stat";
+import type { StatlineData } from "../zod/player-stats";
+
+interface TeamStatsRowProps {
+  totalTeamStats: StatlineData;
+}
+
+export const TeamStatsRow = ({ totalTeamStats }: TeamStatsRowProps) => {
+  const teamStats = calculateTeamStats(totalTeamStats);
+  return (
+    <>
+      <TableCell className="p-3 text-left font-medium dark:text-white">
+        Team
+      </TableCell>
+      <TableCell className="p-3 text-center font-medium dark:text-white">
+        {teamStats.totalPoints}
+      </TableCell>
+      <TableCell className="p-3 text-center font-medium dark:text-white">
+        {teamStats.fieldGoals.made}/{teamStats.fieldGoals.attempted}
+      </TableCell>
+      <TableCell className="p-3 text-center font-medium dark:text-white">
+        {teamStats.threePointers.made}/{teamStats.threePointers.attempted}
+      </TableCell>
+      <TableCell className="p-3 text-center font-medium dark:text-white">
+        {teamStats.freeThrows.made}/{teamStats.freeThrows.attempted}
+      </TableCell>
+      <TableCell className="p-3 text-center font-medium dark:text-white">
+        {totalTeamStats.rebounds ?? 0}
+      </TableCell>
+      <TableCell className="p-3 text-center font-medium dark:text-white">
+        {totalTeamStats.assists ?? 0}
+      </TableCell>
+      <TableCell className="p-3 text-center font-medium dark:text-white">
+        {totalTeamStats.steals ?? 0}
+      </TableCell>
+      <TableCell className="p-3 text-center font-medium dark:text-white">
+        {totalTeamStats.blocks ?? 0}
+      </TableCell>
+      <TableCell className="p-3 text-center font-medium dark:text-white">
+        {totalTeamStats.turnovers ?? 0}
+      </TableCell>
+      <TableCell className="p-3 text-left font-medium dark:text-white"></TableCell>
+    </>
+  );
+};

--- a/src/features/scouting/lib/create-statline.ts
+++ b/src/features/scouting/lib/create-statline.ts
@@ -1,0 +1,14 @@
+import { api } from "@/trpc/react";
+
+export const createNewStatline = () => {
+  const utils = api.useUtils();
+
+  const createStatline = api.stats.submit.useMutation({
+    // onSuccess: async () => {
+    //       await utils.stats.getStatlines.invalidate();
+    onError: (error) => {
+      console.error("Error creating statline:", error);
+    },
+  });
+  return createStatline;
+};

--- a/src/features/scouting/utils/const.ts
+++ b/src/features/scouting/utils/const.ts
@@ -1,14 +1,29 @@
 import type { StatlineData } from "../zod/player-stats";
 
-export const STAT_BUTTONS: { label: string; key: keyof StatlineData }[] = [
-  { label: "FG Made", key: "fieldGoalsMade" },
-  { label: "FG Missed", key: "fieldGoalsMissed" },
-  { label: "3PT Made", key: "threePointersMade" },
-  { label: "3PT Missed", key: "threePointersMissed" },
-  { label: "FT Made", key: "freeThrows" },
-  { label: "FT Missed", key: "missedFreeThrows" },
-  { label: "Assists", key: "assists" },
-  { label: "Steals", key: "steals" },
-  { label: "Turnovers", key: "turnovers" },
-  { label: "Rebounds", key: "rebounds" },
+export const statRows: { key: keyof StatlineData; label: string }[] = [
+  { key: "fieldGoalsMade", label: "FGM" },
+  { key: "fieldGoalsMissed", label: "FG Missed" },
+  { key: "threePointersMade", label: "3PM" },
+  { key: "threePointersMissed", label: "3P Missed" },
+  { key: "freeThrows", label: "FTM" },
+  { key: "missedFreeThrows", label: "FT Missed" },
+  { key: "rebounds", label: "REB" },
+  { key: "assists", label: "AST" },
+  { key: "steals", label: "STL" },
+  { key: "blocks", label: "BLK" },
+  { key: "turnovers", label: "TO" },
+];
+
+export const statKeys: (keyof StatlineData)[] = [
+  "fieldGoalsMade",
+  "fieldGoalsMissed",
+  "threePointersMade",
+  "threePointersMissed",
+  "freeThrows",
+  "missedFreeThrows",
+  "assists",
+  "steals",
+  "turnovers",
+  "rebounds",
+  "blocks",
 ];

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,7 +1,6 @@
 import { activityRouter } from "./routers/activity";
 import { drawRouter } from "./routers/draw";
-import { postRouter } from "./routers/post";
-import { scheduleRouter } from "./routers/schedule";
+import { statsRouter } from "./routers/stats";
 import { teamRouter } from "./routers/team";
 import { userRouter } from "./routers/user";
 import { createCallerFactory, createTRPCRouter } from "./trpc";
@@ -12,12 +11,11 @@ import { createCallerFactory, createTRPCRouter } from "./trpc";
  * All routers added in /api/routers should be manually added here.
  */
 export const appRouter = createTRPCRouter({
-  post: postRouter,
   draw: drawRouter,
   team: teamRouter,
   user: userRouter,
   activity: activityRouter,
-  schedule: scheduleRouter,
+  stats: statsRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/stats.ts
+++ b/src/server/api/routers/stats.ts
@@ -1,0 +1,90 @@
+import { playersDataSchema } from "@/features/scouting/zod/player-stats";
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { createTRPCRouter, protectedProcedure } from "../trpc";
+
+export const statsRouter = createTRPCRouter({
+  submit: protectedProcedure
+    .input(
+      playersDataSchema.extend({
+        players: playersDataSchema.shape.players,
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { players } = input;
+
+      const statlinesToCreate = await Promise.all(
+        players.flatMap(async (player) => {
+          const teamMember = await ctx.db.teamMember.findFirst({
+            where: { userId: player.id },
+            select: {
+              id: true,
+            },
+          });
+
+          if (!teamMember) {
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: `Team member not found for player ID: ${player.id}`,
+            });
+          }
+
+          return player.statlines.map((statline) => ({
+            id: player.id,
+            playerId: player.id,
+            activityId: player.activityId,
+            teamMemberId: teamMember.id,
+            fieldGoalsMade: statline.fieldGoalsMade ?? 0,
+            fieldGoalsMissed: statline.fieldGoalsMissed ?? 0,
+            threePointersMade: statline.threePointersMade ?? 0,
+            threePointersMissed: statline.threePointersMissed ?? 0,
+            freeThrows: statline.freeThrows ?? 0,
+            missedFreeThrows: statline.missedFreeThrows ?? 0,
+            assists: statline.assists ?? 0,
+            rebounds: statline.rebounds ?? 0,
+            steals: statline.steals ?? 0,
+            blocks: statline.blocks ?? 0,
+            turnovers: statline.turnovers ?? 0,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          }));
+        }),
+      ).then((results) => results.flat());
+
+      try {
+        const result = await ctx.db.statline.createMany({
+          data: statlinesToCreate,
+        });
+
+        return { success: true, count: result.count };
+      } catch (error) {
+        console.error("Error creating statlines:", error);
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to create statlines",
+        });
+      }
+    }),
+
+  getStats: protectedProcedure
+    .input(
+      z.object({
+        teamId: z.string(),
+        activityId: z.string(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      const { teamId, activityId } = input;
+
+      const statlines = await ctx.db.statline.findMany({
+        where: {
+          activityId: activityId,
+          teamMember: {
+            teamId: teamId,
+          },
+        },
+        include: {},
+      });
+      return statlines;
+    }),
+});


### PR DESCRIPTION
This pull request introduces several updates, including dependency upgrades, new features for managing team and player statistics, and some refactoring to enhance maintainability and functionality. The most notable changes involve integrating new libraries, modifying the `PlayerBoxScore` component to include team statistics, and introducing a new API route for handling stats.

### Dependency Updates:
* Added `nuqs` (v2.4.3) and `tw-animate-css` (v1.2.9) dependencies, and upgraded `tailwind-merge` to v3.2.0. These updates enhance functionality and styling capabilities. (`package.json`, `pnpm-lock.yaml`) [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R43-R49) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R68) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR65-R67) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL81-R84) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR136-R138) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3636-R3639) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3724-R3746) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4530-R4533)

### Feature Enhancements:
* Introduced team statistics in the `PlayerBoxScore` component, including a new footer row displaying aggregated stats for the entire team. (`multi-stats-tracker.tsx`, `team-stats-row.tsx`) [[1]](diffhunk://#diff-a6219d3960b1fe7c0419a4fddfc1e84e75a8b10582c8c83dda46135361c14fa6L37-R95) [[2]](diffhunk://#diff-a6219d3960b1fe7c0419a4fddfc1e84e75a8b10582c8c83dda46135361c14fa6R164-R170) [[3]](diffhunk://#diff-621c0346a83764fe79291a1e8c8092c910190bb55600905f8e7b2f013becceabR1-R46)
* Added a `Submit Stats` button and integrated a mutation to save player stats using the new `createNewStatline` utility. (`multi-stats-tracker.tsx`, `create-statline.ts`) [[1]](diffhunk://#diff-a6219d3960b1fe7c0419a4fddfc1e84e75a8b10582c8c83dda46135361c14fa6R107-R126) [[2]](diffhunk://#diff-422cd945b8c36d2a59485aeb3964881228c9bade7d39137a00d211a06df6c45aR1-R14)

### Refactoring:
* Refactored `PlayerStatsRow` to simplify the calculation of individual player stats by directly passing the `statsForPlayer` object to `calculateStats`. (`player-stat-row.tsx`) [[1]](diffhunk://#diff-ebbcd0acc9da5a02a7ece47291df51b6215627510b3ad3621e63d7671560503fL22-R32) [[2]](diffhunk://#diff-ebbcd0acc9da5a02a7ece47291df51b6215627510b3ad3621e63d7671560503fL67-R61)
* Reorganized constants in `const.ts` to improve readability and maintainability by separating `statRows` and `statKeys`. (`const.ts`)

### Backend Changes:
* Removed unused API routes (`postRouter` and `scheduleRouter`) and added a new `statsRouter` for handling statistics-related operations. (`root.ts`) [[1]](diffhunk://#diff-6a8cad7e52067d5afa93671900c038e0e0a9526f8f0e3bd10985cecf4295b4fcL3-R3) [[2]](diffhunk://#diff-6a8cad7e52067d5afa93671900c038e0e0a9526f8f0e3bd10985cecf4295b4fcL15-R18)

### Database Schema:
* Removed the `playerId` field from the `Statline` model in the Prisma schema, likely to align with the new team-based statistics approach. (`schema.prisma`)