### PR TITLE
Restore attendance modal form state

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -167,7 +167,9 @@ model ActivityAttendance {
   teamMemberId     String       
   attendanceStatus String
   reason           String?
-  attendedAt       DateTime?
+
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   // Relationships
   activity     Activity      @relation(fields: [activityId], references: [id])

--- a/src/components/foundation/button/button.tsx
+++ b/src/components/foundation/button/button.tsx
@@ -37,12 +37,21 @@ const buttonVariants = cva(
 export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean;
+    icon?: React.ReactNode;
     type?: ButtonHTMLAttributes<HTMLButtonElement>["type"];
   };
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
-    { className, type = "button", variant, size, asChild = false, ...props },
+    {
+      className,
+      type = "button",
+      variant,
+      size,
+      asChild = false,
+
+      ...props
+    },
     ref,
   ) => {
     const Comp = asChild && type !== "submit" ? Slot : "button";

--- a/src/features/attendance/components/attendance-modal.tsx
+++ b/src/features/attendance/components/attendance-modal.tsx
@@ -8,7 +8,7 @@ import useStore from "@/store/store";
 import type { UserTeamMember } from "@/types";
 import { format } from "date-fns";
 import { X } from "lucide-react";
-import { useEffect, useState, type FC } from "react";
+import { useState, type FC } from "react";
 import { Controller, useForm, useWatch } from "react-hook-form";
 import { useAttendance } from "../hooks/use-attendance";
 import { attendanceStatus } from "../utils/const";
@@ -39,19 +39,8 @@ const AttendanceModal: FC<AttendanceProps> = ({ mode, member }) => {
           | "LATE"
           | undefined) ?? undefined,
       reason:
-        selectedActivity?.attendees?.find(
-          (a) => a.teamMemberId === member?.id,
-        ) &&
-        "reason" in
-          (selectedActivity?.attendees?.find(
-            (a) => a.teamMemberId === member?.id,
-          ) as object)
-          ? (
-              selectedActivity?.attendees?.find(
-                (a) => a.teamMemberId === member?.id,
-              ) as { reason?: string }
-            ).reason
-          : undefined,
+        selectedActivity?.attendees?.find((a) => a.teamMemberId === member?.id)
+          ?.reason ?? "",
     },
   });
 
@@ -64,10 +53,6 @@ const AttendanceModal: FC<AttendanceProps> = ({ mode, member }) => {
   );
   const attendanceSelection = useWatch({ control, name: "attendanceStatus" });
 
-  useEffect(() => {
-    setFormState(mode);
-  }, [mode]);
-
   const formattedDate =
     selectedActivity && format(selectedActivity.date, "EEEE, d MMM");
 
@@ -79,16 +64,16 @@ const AttendanceModal: FC<AttendanceProps> = ({ mode, member }) => {
       throw new Error("Team member is required.");
     }
 
-    // Save to localStorage
-    localStorage.setItem(
-      `attendance-${member.id}-${selectedActivity.id}`,
-      JSON.stringify(attendance),
-    );
-
     await submitAttendance.mutateAsync({
       ...attendance,
       activityId: selectedActivity.id,
       teamMemberId: member.id,
+    });
+    reset({
+      activityId: selectedActivity?.id ?? "",
+      teamMemberId: member?.id ?? "",
+      attendanceStatus: attendance.attendanceStatus,
+      reason: attendance.reason,
     });
   };
   return (

--- a/src/features/schedule/components/activity/activity-card.tsx
+++ b/src/features/schedule/components/activity/activity-card.tsx
@@ -6,15 +6,13 @@ import { useTeam } from "@/context/team-context";
 import { useRole } from "@/hooks/use-role";
 import { cn } from "@/lib/utils";
 import useStore from "@/store/store";
-import type { Activity, TeamInformation } from "@/types";
+import type { Activity } from "@/types";
 import { getActivityStyle } from "@/utils";
-
 import { Clock } from "lucide-react";
 import { type FC } from "react";
 
 type ActivityCardProps = {
   activity: Activity;
-  team: TeamInformation;
 };
 
 export const ActivityCard: FC<ActivityCardProps> = ({ activity }) => {
@@ -22,7 +20,6 @@ export const ActivityCard: FC<ActivityCardProps> = ({ activity }) => {
   const { role } = useRole();
 
   const {
-    selectedActivity,
     setOpenPracticeDetails,
     setOpenGameDetails,
     setSelectedActivity,

--- a/src/features/schedule/components/activity/activity-list.tsx
+++ b/src/features/schedule/components/activity/activity-list.tsx
@@ -68,7 +68,7 @@ export function ActivityList({
       {filteredActivities.length > 0 ? (
         <div className="scrollbar-none mb-6 max-h-96 space-y-2 overflow-y-auto pr-2">
           {filteredActivities.map((activity) => (
-            <ActivityCard key={activity.id} activity={activity} team={team} />
+            <ActivityCard key={activity.id} activity={activity} />
           ))}
         </div>
       ) : (

--- a/src/features/schedule/index.tsx
+++ b/src/features/schedule/index.tsx
@@ -12,7 +12,7 @@ const ScheduleBlock = async ({
   activities: Activity[];
   team: TeamInformation;
 }) => {
-  const role = (await getRole()) as TeamMemberRole;
+  const role = await getRole();
   const { teamMember } = await getUser();
 
   return (
@@ -20,7 +20,7 @@ const ScheduleBlock = async ({
       <div className="h-full w-full max-w-7xl">
         <HorizontalCalender activities={activities} team={team} />
         <ActivityList
-          role={role}
+          role={role as TeamMemberRole}
           activities={activities}
           team={team}
           member={teamMember}


### PR DESCRIPTION
This pull request introduces several updates across the codebase, focusing on schema improvements, component enhancements, and code cleanup. The changes include updates to the Prisma schema, new functionality for buttons, simplification of attendance modal logic, and removal of unused or redundant code in the schedule-related components.

### Schema and Model Updates:
* Added `createdAt` and `updatedAt` fields with default values to the `ActivityAttendance` model in `prisma/schema.prisma` to track record creation and updates.

### Component Enhancements:
* Added an optional `icon` property to the `ButtonProps` type in `src/components/foundation/button/button.tsx` to support buttons with icons.

### Attendance Modal Improvements:
* Simplified the logic for retrieving the `reason` field in the `AttendanceModal` component by removing redundant code and using optional chaining.
* Removed the `useEffect` hook that set the form state based on the mode, as it was no longer needed.
* Replaced localStorage usage with a `reset` function to update the form state after submitting attendance.

### Code Cleanup:
* Removed the unused `team` property from the `ActivityCard` component and its references in `activity-card.tsx` and `activity-list.tsx`. [[1]](diffhunk://#diff-85086f7383962b18565f48d0dcf0f10ab307fcd195d0ca75e775b4fae12056ceL9-L25) [[2]](diffhunk://#diff-98ad4216fca7a312b7b30e1b8730ad68f5c214d58db03ef29f83116ef1c85c86L71-R71)
* Removed unnecessary type casting for `role` in the `ScheduleBlock` component to simplify the code.