### PR TITLE
feat: create OpponentStatline model and update Activity model for enh…

### DIFF
--- a/prisma/migrations/20250531181024_opponent_statline_model/migration.sql
+++ b/prisma/migrations/20250531181024_opponent_statline_model/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "OpponentStatline" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "activityId" TEXT NOT NULL,
+    "twoPointersMade" INTEGER NOT NULL,
+    "threePointersMade" INTEGER NOT NULL,
+    "freeThrowsMade" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "OpponentStatline_activityId_fkey" FOREIGN KEY ("activityId") REFERENCES "Activity" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OpponentStatline_activityId_key" ON "OpponentStatline"("activityId");

--- a/prisma/migrations/20250531212328_add_field_goal_made_to_opponent_statline/migration.sql
+++ b/prisma/migrations/20250531212328_add_field_goal_made_to_opponent_statline/migration.sql
@@ -1,0 +1,28 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `twoPointersMade` on the `OpponentStatline` table. All the data in the column will be lost.
+  - Added the required column `fieldGoalMade` to the `OpponentStatline` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_OpponentStatline" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "name" TEXT NOT NULL,
+    "activityId" TEXT NOT NULL,
+    "fieldGoalMade" INTEGER NOT NULL,
+    "threePointersMade" INTEGER NOT NULL,
+    "freeThrowsMade" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "OpponentStatline_activityId_fkey" FOREIGN KEY ("activityId") REFERENCES "Activity" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_OpponentStatline" ("activityId", "createdAt", "freeThrowsMade", "id", "name", "threePointersMade", "updatedAt") SELECT "activityId", "createdAt", "freeThrowsMade", "id", "name", "threePointersMade", "updatedAt" FROM "OpponentStatline";
+DROP TABLE "OpponentStatline";
+ALTER TABLE "new_OpponentStatline" RENAME TO "OpponentStatline";
+CREATE UNIQUE INDEX "OpponentStatline_activityId_key" ON "OpponentStatline"("activityId");
+CREATE UNIQUE INDEX "opponent_activity_unique" ON "OpponentStatline"("activityId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -114,24 +114,24 @@ model TeamMember {
 
 // Activity table
 model Activity {
-  id           String      @id @default(cuid())
-  title        String
-  time         String
-  gameplan     String?
-  type         String
-  duration     Float?
-  practiceType String?
-  notes        String?
-  date         DateTime
-  createdAt    DateTime
-  updatedAt    DateTime
-  teamId       String
+  id                String              @id @default(cuid())
+  title             String
+  time              String
+  gameplan          String?
+  type              String
+  duration          Float?
+  practiceType      String?
+  notes             String?
+  date              DateTime
+  createdAt         DateTime
+  updatedAt         DateTime
+  teamId            String
 
-  attendees    ActivityAttendance[]
-  statlines    Statline[]
+  attendees         ActivityAttendance[]
+  statlines         Statline[]
   
-  // Relationships
-  team         Team          @relation(fields: [teamId], references: [id])
+  opponentStatline  OpponentStatline?
+  team              Team                  @relation(fields: [teamId], references: [id])
  
 }
 
@@ -177,4 +177,18 @@ model ActivityAttendance {
 @@unique([activityId, teamMemberId]) // Ensure unique attendance per activity and team member
   @@index([activityId])
   @@index([teamMemberId])
+}
+
+model OpponentStatline {
+  id                String    @id @default(cuid())
+  name              String
+  activityId        String    @unique
+  fieldGoalMade     Int
+  threePointersMade Int
+  freeThrowsMade    Int
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+
+  activity         Activity   @relation(fields: [activityId], references: [id])
+  @@unique([activityId], map: "opponent_activity_unique")
 }


### PR DESCRIPTION
This pull request introduces a new `OpponentStatline` model to the database schema, along with accompanying migrations to create and update the relevant table. The changes also establish a relationship between `OpponentStatline` and `Activity`. Additionally, the schema has been updated to replace the `twoPointersMade` column with `fieldGoalMade` in the `OpponentStatline` table.

### Database Schema Updates:

* Added the `OpponentStatline` model to the Prisma schema with fields such as `id`, `name`, `activityId`, `fieldGoalMade`, `threePointersMade`, and `freeThrowsMade`. The model includes a relationship to `Activity` and a unique constraint on `activityId`. (`prisma/schema.prisma`, [prisma/schema.prismaR181-R194](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR181-R194))
* Updated the `Activity` model to include an optional relationship to `OpponentStatline`. (`prisma/schema.prisma`, [prisma/schema.prismaL133-R133](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL133-R133))

### Migrations:

* Created the initial `OpponentStatline` table with fields and constraints, including a foreign key to the `Activity` table and a unique index on `activityId`. (`prisma/migrations/20250531181024_opponent_statline_model/migration.sql`, [prisma/migrations/20250531181024_opponent_statline_model/migration.sqlR1-R15](diffhunk://#diff-0ad37d6e938ff2db8f9d9f0dfcb79abedb26919674239d9e526c1552b3ddf9f4R1-R15))
* Modified the `OpponentStatline` table by replacing the `twoPointersMade` column with `fieldGoalMade`, requiring data migration and table redefinition. Added a new unique index `opponent_activity_unique` on `activityId`. (`prisma/migrations/20250531212328_add_field_goal_made_to_opponent_statline/migration.sql`, [prisma/migrations/20250531212328_add_field_goal_made_to_opponent_statline/migration.sqlR1-R28](diffhunk://#diff-1e7a104a5e56da24950bbe787ba104331dcededa4f702b4bc95f1be3d1fdc4b7R1-R28))…anced statistics tracking