### PR TITLE
Loading Stat skeleton screens

### DIFF
--- a/src/app/[teamId]/playbook-library/create/page.tsx
+++ b/src/app/[teamId]/playbook-library/create/page.tsx
@@ -1,9 +1,13 @@
+import CreatePlaySkeleton from "@/features/play-book/components/skeleton/create-play-skeleton";
 import { PlayForm } from "@/features/play-book/form/play-form";
+import { Suspense } from "react";
 
 async function PlayPage() {
   return (
     <div className="scrollbar-none flex overflow-y-auto">
-      <PlayForm />
+      <Suspense fallback={<CreatePlaySkeleton />}>
+        <PlayForm />
+      </Suspense>
     </div>
   );
 }

--- a/src/app/[teamId]/playbook-library/gameplan/page.tsx
+++ b/src/app/[teamId]/playbook-library/gameplan/page.tsx
@@ -1,5 +1,7 @@
 import { getGamePlanById } from "@/api/play";
+import PlanViewSkeleton from "@/features/play-book/components/skeleton/plan-view-skeleton";
 import { gameplanSearchParamsCache } from "@/utils/search-params";
+import { Suspense } from "react";
 
 type PageProps = {
   searchParams: Promise<{ id: string }>;
@@ -18,22 +20,24 @@ async function GamePlanView({ searchParams }: PageProps) {
   }
 
   return (
-    <div className="scrollbar-none h-screen overflow-y-auto pt-10">
-      <div className="mx-auto max-w-7xl md:px-4">
-        <h1 className="font-righteous mb-4 text-3xl font-bold text-white">
-          Game Plan
-        </h1>
+    <Suspense fallback={<PlanViewSkeleton />}>
+      <div className="scrollbar-none h-screen overflow-y-auto pt-10">
+        <div className="mx-auto max-w-7xl md:px-4">
+          <h1 className="font-righteous mb-4 text-3xl font-bold text-white">
+            Game Plan
+          </h1>
 
-        <div className="flex flex-col p-0 sm:relative sm:flex-row sm:items-start md:gap-8">
-          <div className="top-4 right-0 mb-4 w-full sm:absolute sm:mb-0 sm:w-3/7"></div>
+          <div className="flex flex-col p-0 sm:relative sm:flex-row sm:items-start md:gap-8">
+            <div className="top-4 right-0 mb-4 w-full sm:absolute sm:mb-0 sm:w-3/7"></div>
 
-          <div
-            className="prose prose-invert prose-h1:text-2xl prose-ul:py-0 prose-li:py-0 prose-strong:font-extrabold prose-h2:text-lg max-w-none rounded p-4 text-white"
-            dangerouslySetInnerHTML={{ __html: gameplan.notes ?? "" }}
-          />
+            <div
+              className="prose prose-invert prose-h1:text-2xl prose-ul:py-0 prose-li:py-0 prose-strong:font-extrabold prose-h2:text-lg max-w-none rounded p-4 text-white"
+              dangerouslySetInnerHTML={{ __html: gameplan.notes ?? "" }}
+            />
+          </div>
         </div>
       </div>
-    </div>
+    </Suspense>
   );
 }
 

--- a/src/app/[teamId]/playbook-library/page.tsx
+++ b/src/app/[teamId]/playbook-library/page.tsx
@@ -3,8 +3,10 @@ import { getGameplan, getPlays, getPracticePreparations } from "@/api/play";
 import { getRole } from "@/api/role";
 import withAuth from "@/features/auth/components/with-auth";
 import PlaybookBookBlock from "@/features/play-book/components/playbook";
+import PlaybookLibrarySkeleton from "@/features/play-book/components/skeleton/playb-book-library-skeleton";
 import GamePlanForm from "@/features/play-book/form/gameplan-form";
 import PracticePreparationForm from "@/features/play-book/form/practice-preparation-form";
+import { Suspense } from "react";
 
 type PageProps = {
   params: Promise<{ teamId: string }>;
@@ -20,27 +22,30 @@ async function PlaybookPage({ params }: PageProps) {
   const role = await getRole();
 
   return (
-    <div className="scrollbar-none h-auto max-w-screen-2xl overflow-y-auto">
-      <PlaybookBookBlock
-        practicePreparation={practicePreparation}
-        practices={practices}
-        role={role}
-        playbook={playbook}
-        gamePlan={gameplan}
-      />
-      <GamePlanForm
-        mode="create"
-        role={role}
-        games={games}
-        playbook={playbook}
-      />
-      <PracticePreparationForm
-        mode="create"
-        role={role}
-        practices={practices}
-        playbook={playbook}
-      />
-    </div>
+    <Suspense fallback={<PlaybookLibrarySkeleton />}>
+      <div className="scrollbar-none h-auto max-w-screen-2xl overflow-y-auto">
+        <PlaybookBookBlock
+          practicePreparation={practicePreparation}
+          practices={practices}
+          role={role}
+          playbook={playbook}
+          gamePlan={gameplan}
+        />
+
+        <GamePlanForm
+          mode="create"
+          role={role}
+          games={games}
+          playbook={playbook}
+        />
+        <PracticePreparationForm
+          mode="create"
+          role={role}
+          practices={practices}
+          playbook={playbook}
+        />
+      </div>
+    </Suspense>
   );
 }
 

--- a/src/app/[teamId]/playbook-library/play/page.tsx
+++ b/src/app/[teamId]/playbook-library/play/page.tsx
@@ -1,6 +1,8 @@
 import { getPlayById } from "@/api/play";
+import PlanViewSkeleton from "@/features/play-book/components/skeleton/plan-view-skeleton";
 import { playbookSearchParamsCache } from "@/utils/search-params";
 import Image from "next/image";
+import { Suspense } from "react";
 
 type PageProps = {
   searchParams: Promise<{ id: string }>;
@@ -19,30 +21,31 @@ async function PlayView({ searchParams }: PageProps) {
   }
 
   return (
-    <div className="scrollbar-none h-screen overflow-y-auto pt-10">
-      <div className="mx-auto max-w-7xl md:px-4">
-        <h1 className="font-righteous mb-4 text-3xl font-bold text-white">
-          Play
-        </h1>
+    <Suspense fallback={<PlanViewSkeleton />}>
+      <div className="scrollbar-none h-screen overflow-y-auto px-4 pt-10">
+        <div className="mx-auto max-w-7xl md:px-4">
+          <h1 className="font-righteous mb-4 text-3xl font-bold text-white">
+            Play
+          </h1>
 
-        <div className="flex flex-col p-0 sm:relative sm:flex-row sm:items-start md:gap-8">
-          <div className="top-4 right-0 mb-4 w-full sm:absolute sm:mb-0 sm:w-3/7">
-            <Image
-              src={play?.canvas}
-              alt={play.name}
-              className="h-auto w-full rounded-xl border-2 object-cover"
-              width={600}
-              height={400}
+          <div className="flex flex-col p-0 sm:flex-row sm:items-start md:gap-8">
+            <div
+              className="prose prose-invert prose-h1:text-2xl prose-ul:py-0 prose-li:py-0 prose-strong:font-extrabold prose-h2:text-lg max-w-none text-white"
+              dangerouslySetInnerHTML={{ __html: play.description ?? "" }}
             />
+            <div className="mb-4 flex-shrink-0 sm:mr-6 sm:mb-0 sm:w-2/5">
+              <Image
+                src={play?.canvas}
+                alt={play.name}
+                className="h-auto w-full rounded-xl border-2 object-cover"
+                width={600}
+                height={600}
+              />
+            </div>
           </div>
-
-          <div
-            className="prose prose-invert prose-h1:text-2xl prose-ul:py-0 prose-li:py-0 prose-strong:font-extrabold prose-h2:text-lg max-w-none rounded p-4 text-white"
-            dangerouslySetInnerHTML={{ __html: play.description ?? "" }}
-          />
         </div>
       </div>
-    </div>
+    </Suspense>
   );
 }
 

--- a/src/app/[teamId]/schedule/page.tsx
+++ b/src/app/[teamId]/schedule/page.tsx
@@ -1,8 +1,10 @@
 import { getTeamActivities } from "@/api/team";
 import withAuth from "@/features/auth/components/with-auth";
 import { ScheduleBlock } from "@/features/schedule";
+import { ScheduleSkeleton } from "@/features/schedule/components/schedule-skeleton";
 
 import { redirect } from "next/navigation";
+import { Suspense } from "react";
 
 async function SchedulePage({
   params,
@@ -17,6 +19,10 @@ async function SchedulePage({
     redirect("/create-team");
   }
 
-  return <ScheduleBlock activities={activities} team={team} />;
+  return (
+    <Suspense fallback={<ScheduleSkeleton />}>
+      <ScheduleBlock activities={activities} team={team} />
+    </Suspense>
+  );
 }
 export default withAuth(SchedulePage);

--- a/src/app/[teamId]/statistics/page.tsx
+++ b/src/app/[teamId]/statistics/page.tsx
@@ -2,6 +2,8 @@ import { getStatlineAverage, getTeamStats } from "@/api/statline";
 import { getTeam } from "@/api/team";
 import WithAuth from "@/features/auth/components/with-auth";
 import StatisticsBlock from "@/features/statistics";
+import StatisticsSkeleton from "@/features/statistics/components/skeleton-statistics";
+import { Suspense } from "react";
 
 type PageProps = {
   params: Promise<{ teamId: string }>;
@@ -23,7 +25,13 @@ async function StatisticsPage({ params }: PageProps) {
 
   return (
     <div className="scrollbar-none overflow-y-auto">
-      <StatisticsBlock teamStatlist={stats} statsList={statsList} team={team} />
+      <Suspense fallback={<StatisticsSkeleton />}>
+        <StatisticsBlock
+          teamStatlist={stats}
+          statsList={statsList}
+          team={team}
+        />
+      </Suspense>
     </div>
   );
 }

--- a/src/app/[teamId]/statistics/player/page.tsx
+++ b/src/app/[teamId]/statistics/player/page.tsx
@@ -1,9 +1,11 @@
 import { getStatlineAverage } from "@/api/statline";
+import PlayerDetailSkeleton from "@/features/statistics/components/player-detail/player-detail-skeleton";
 import { PlayerDetailStatistics } from "@/features/statistics/components/player-detail/player-detail-statistics";
 import type { PlayerStatRow } from "@/features/statistics/utils/types";
 import { boxScoreSearchParamsCache } from "@/utils/search-params";
 import { notFound } from "next/navigation";
 import type { SearchParams } from "nuqs/server";
+import { Suspense } from "react";
 
 type PageProps = {
   searchParams: Promise<SearchParams>;
@@ -37,7 +39,11 @@ async function PlayerStatisticsDetailPage({ params, searchParams }: PageProps) {
     turnovers: player.averages.turnovers,
   };
 
-  return <PlayerDetailStatistics player={mappedPlayer} />;
+  return (
+    <Suspense fallback={<PlayerDetailSkeleton />}>
+      <PlayerDetailStatistics player={mappedPlayer} />
+    </Suspense>
+  );
 }
 
 export default PlayerStatisticsDetailPage;

--- a/src/components/skeleton/playcard-skeleton.tsx
+++ b/src/components/skeleton/playcard-skeleton.tsx
@@ -1,0 +1,13 @@
+import { SkeletonBox } from "./skeleton-box";
+
+export const PlayCardSkeleton = () => (
+  <div className="w-[240px] space-y-4 rounded-xl border border-neutral-700 bg-neutral-900 p-4">
+    <SkeletonBox className="h-5 w-20 rounded-full" />
+    <SkeletonBox className="h-32 w-full rounded-lg" />
+    <SkeletonBox className="h-4 w-32" />
+    <div className="flex justify-between gap-2">
+      <SkeletonBox className="h-8 w-24 rounded-md" />
+      <SkeletonBox className="h-8 w-16 rounded-md bg-red-800" />
+    </div>
+  </div>
+);

--- a/src/components/skeleton/skeleton-box.tsx
+++ b/src/components/skeleton/skeleton-box.tsx
@@ -1,0 +1,3 @@
+export const SkeletonBox = ({ className = "" }: { className?: string }) => (
+  <div className={`animate-pulse rounded-md bg-neutral-800 ${className}`} />
+);

--- a/src/features/play-book/components/skeleton/create-play-skeleton.tsx
+++ b/src/features/play-book/components/skeleton/create-play-skeleton.tsx
@@ -1,0 +1,55 @@
+import { SkeletonBox } from "@/components/skeleton/skeleton-box";
+
+export default function CreatePlaySkeleton() {
+  return (
+    <div className="flex min-h-screen w-full flex-col items-center justify-center space-y-8 bg-black px-6 py-8 text-white">
+      <SkeletonBox className="h-4 w-full max-w-7xl" />
+
+      <SkeletonBox className="h-10 w-full max-w-7xl" />
+      <SkeletonBox className="h-5 w-full max-w-7xl" />
+
+      <div className="w-full max-w-7xl space-y-6 rounded-xl border border-neutral-700 bg-gray-700 p-6">
+        <div className="space-y-2">
+          <SkeletonBox className="h-4 w-24" />
+          <SkeletonBox className="h-10 w-full" />
+        </div>
+
+        <div className="w-full space-y-2">
+          <SkeletonBox className="h-4 w-32" />
+          <div className="flex gap-4">
+            <SkeletonBox className="h-10 w-24" />
+            <SkeletonBox className="h-10 w-24" />
+            <SkeletonBox className="h-10 w-24" />
+          </div>
+        </div>
+
+        <div className="w-full space-y-2">
+          <SkeletonBox className="h-4 w-40" />
+          <SkeletonBox className="h-10 w-full" />
+          <SkeletonBox className="h-40 w-full" />
+        </div>
+        <SkeletonBox className="h-12 w-full rounded-lg bg-neutral-700" />
+      </div>
+
+      <div className="w-full max-w-7xl space-y-4 rounded-xl border border-neutral-700 bg-neutral-900 p-6">
+        <div className="flex flex-wrap gap-4">
+          <SkeletonBox className="h-8 w-20" />
+          <SkeletonBox className="h-8 w-20" />
+          <SkeletonBox className="h-8 w-24" />
+          <SkeletonBox className="h-8 w-24" />
+          <SkeletonBox className="h-8 w-28" />
+        </div>
+
+        <div className="mt-4 flex gap-3">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-6 w-6 animate-pulse rounded-full bg-neutral-700"
+            />
+          ))}
+        </div>
+        <SkeletonBox className="h-80 w-full rounded-lg bg-neutral-800" />
+      </div>
+    </div>
+  );
+}

--- a/src/features/play-book/components/skeleton/plan-view-skeleton.tsx
+++ b/src/features/play-book/components/skeleton/plan-view-skeleton.tsx
@@ -1,0 +1,24 @@
+import { SkeletonBox } from "@/components/skeleton/skeleton-box";
+
+export default function PlanViewSkeleton() {
+  return (
+    <div className="scrollbar-none h-screen overflow-y-auto px-4 pt-10">
+      <div className="mx-auto max-w-7xl md:px-4">
+        <SkeletonBox className="mb-4 h-8 w-32 rounded-md" />
+
+        <div className="flex flex-col p-0 sm:flex-row sm:items-start md:gap-8">
+          <div className="mb-6 w-full flex-1 space-y-3 text-white">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <SkeletonBox key={i} className="h-4 w-full rounded bg-gray-700" />
+            ))}
+            <SkeletonBox className="h-4 w-3/4 rounded bg-gray-700" />
+          </div>
+
+          <div className="mb-4 flex-shrink-0 sm:mr-6 sm:mb-0 sm:w-2/5">
+            <SkeletonBox className="h-80 w-full rounded-xl border-2 bg-gray-800" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/play-book/components/skeleton/playb-book-library-skeleton.tsx
+++ b/src/features/play-book/components/skeleton/playb-book-library-skeleton.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { PlayCardSkeleton } from "@/components/skeleton/playcard-skeleton";
+import { SkeletonBox } from "@/components/skeleton/skeleton-box";
+
+export default function PlaybookLibrarySkeleton() {
+  return (
+    <div className="min-h-screen max-w-screen bg-black px-8 py-10 text-white">
+      <SkeletonBox className="mb-6 h-6 w-40" />
+      <SkeletonBox className="mb-10 h-10 w-48" />
+
+      <div className="mb-8 flex gap-4">
+        <SkeletonBox className="h-10 w-32" />
+        <SkeletonBox className="h-10 w-32" />
+        <SkeletonBox className="h-10 w-32" />
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <PlayCardSkeleton key={i} />
+        ))}
+
+        <div className="flex h-[280px] w-[240px] flex-col items-center justify-center rounded-xl border border-neutral-700 bg-neutral-900">
+          <SkeletonBox className="mb-4 h-12 w-12 rounded-full" />
+          <SkeletonBox className="h-4 w-24" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/schedule/components/schedule-skeleton.tsx
+++ b/src/features/schedule/components/schedule-skeleton.tsx
@@ -1,0 +1,41 @@
+import { SkeletonBox } from "@/components/skeleton/skeleton-box";
+import { CalendarClock } from "lucide-react";
+
+export const ScheduleSkeleton = () => {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="max-h-full min-h-60 w-full animate-pulse rounded-xl border border-orange-200/30 bg-gray-950 p-3 shadow-2xl md:p-6">
+        <div className="mb-4 flex items-center justify-between">
+          <SkeletonBox className="h-6 w-40 rounded-md" />
+          <div className="flex space-x-2">
+            <SkeletonBox className="h-8 w-8 rounded-md" />
+            <SkeletonBox className="h-8 w-8 rounded-md" />
+          </div>
+        </div>
+        <div className="grid grid-cols-3 gap-1 md:grid-cols-5">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <SkeletonBox key={index} className="h-24 w-full rounded-lg" />
+          ))}
+        </div>
+      </div>
+      <div className="mt-3 flex animate-pulse flex-col rounded-xl border border-orange-200/30 bg-gray-950 p-4 shadow-sm sm:p-6">
+        <div className="mb-6 flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+          <h2 className="flex items-center text-xl font-semibold text-white">
+            <CalendarClock className="mr-2 h-5 text-sm text-gray-400" />
+            <SkeletonBox className="h-6 w-48 rounded-md" />
+          </h2>
+          <SkeletonBox className="h-8 w-32 rounded-md" />
+        </div>
+        <div className="flex flex-col gap-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <SkeletonBox key={i} className="h-20 w-full rounded-lg" />
+          ))}
+        </div>
+        <div className="mt-6 flex w-full items-end justify-center gap-4 pt-4">
+          <SkeletonBox className="h-12 w-1/2 rounded-lg" />
+          <SkeletonBox className="h-12 w-1/2 rounded-lg" />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/statistics/components/player-detail/player-detail-skeleton.tsx
+++ b/src/features/statistics/components/player-detail/player-detail-skeleton.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { SkeletonBox } from "@/components/skeleton/skeleton-box";
+
+export default function PlayerDetailSkeleton() {
+  return (
+    <div className="flex h-screen flex-col bg-black px-6 py-8 text-white">
+      <div className="mb-6 flex items-center justify-between">
+        <SkeletonBox className="h-8 w-40" />
+        <SkeletonBox className="h-6 w-32 rounded-full" />
+      </div>
+
+      <div className="mb-8 flex justify-center gap-4">
+        <SkeletonBox className="h-12 w-48 rounded-lg" />
+        <SkeletonBox className="h-12 w-48 rounded-lg" />
+      </div>
+
+      <div className="mb-4 flex justify-end">
+        <SkeletonBox className="h-8 w-48 rounded-md" />
+      </div>
+
+      <div className="mb-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <SkeletonBox key={i} className="h-28 w-full rounded-lg" />
+        ))}
+      </div>
+
+      <SkeletonBox className="mb-4 h-6 w-60" />
+      <SkeletonBox className="h-64 w-full rounded-lg" />
+
+      <div className="mt-6 flex justify-center gap-4">
+        <SkeletonBox className="h-10 w-24 rounded-md" />
+        <SkeletonBox className="h-10 w-24 rounded-md" />
+      </div>
+    </div>
+  );
+}

--- a/src/features/statistics/components/skeleton-statistics.tsx
+++ b/src/features/statistics/components/skeleton-statistics.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { SkeletonBox } from "@/components/skeleton/skeleton-box";
+
+export default function StatisticsSkeleton() {
+  return (
+    <div className="flex h-screen flex-col bg-black px-6 py-8 text-white">
+      <div className="mb-6 flex items-center justify-between">
+        <SkeletonBox className="h-8 w-40" />
+        <SkeletonBox className="h-6 w-32 rounded-full" />
+      </div>
+      <div className="mb-10 text-center">
+        <SkeletonBox className="mx-auto h-10 w-40" />
+        <SkeletonBox className="mx-auto mt-4 h-6 w-60" />
+      </div>
+
+      <div className="mb-8 flex justify-center gap-4">
+        <SkeletonBox className="h-12 w-48 rounded-lg" />
+        <SkeletonBox className="h-12 w-48 rounded-lg" />
+      </div>
+
+      <div className="mb-4 flex justify-end">
+        <SkeletonBox className="h-8 w-48 rounded-md" />
+      </div>
+
+      <div className="mb-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <SkeletonBox key={i} className="h-28 w-full rounded-lg" />
+        ))}
+      </div>
+
+      <SkeletonBox className="mb-4 h-6 w-60" />
+      <SkeletonBox className="h-64 w-full rounded-lg" />
+
+      <div className="mt-6 flex justify-center gap-4">
+        <SkeletonBox className="h-10 w-24 rounded-md" />
+        <SkeletonBox className="h-10 w-24 rounded-md" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request introduces skeleton loading components across various pages and features to improve the user experience during data fetching. It ensures consistent design and better feedback for users when content is loading. The most important changes include adding `Suspense` wrappers to pages, creating reusable skeleton components, and integrating these skeletons into specific pages.

### Integration of Skeleton Loading Components:

* **Suspense Wrappers for Pages**:
  - Added `Suspense` components with fallback skeletons to pages such as `create/page.tsx`, `gameplan/page.tsx`, `play/page.tsx`, `schedule/page.tsx`, `statistics/page.tsx`, and `statistics/player/page.tsx`. This ensures placeholders are displayed while data is being fetched. ([src/app/[teamId]/playbook-library/create/page.tsxR1-R10](diffhunk://#diff-fc58ca5fb7d08b9581aaee9f85f6ef07f50c335660916f11a71ee9dca4f1555aR1-R10), [src/app/[teamId]/playbook-library/gameplan/page.tsxR2-R4](diffhunk://#diff-171ad71441a62ae4f036a207a2f34a0faa42063f3cccba151795277e63d35172R2-R4), [src/app/[teamId]/playbook-library/page.tsxR25](diffhunk://#diff-d0283809825abb9a9834a861a620b5ac98d2efd1d682e503173d727544e3c7a7R25), [src/app/[teamId]/playbook-library/play/page.tsxL22-R48](diffhunk://#diff-47fc40b8042ea627c8eadcadc6f377a8976732a6f53ca761f4ffbe49a593f3eeL22-R48), [src/app/[teamId]/schedule/page.tsxL20-R26](diffhunk://#diff-15b8d5c245eadb0edd6f4f995b6bbe74d0132ebc53ba363d5e63cece1847370dL20-R26), [src/app/[teamId]/statistics/page.tsxL26-R34](diffhunk://#diff-d9318a874880d1554f628975f52dd3cfb410d805faf89faf178d625fe54f6bf1L26-R34), [src/app/[teamId]/statistics/player/page.tsxL40-R46](diffhunk://#diff-db98c3407bef1fbe74ea529d3b8eda6db77ce8b6b7ea5013362e02699ff9a536L40-R46))

### Creation of Skeleton Components:

* **Reusable Skeleton Components**:
  - Introduced `SkeletonBox`, a generic skeleton placeholder component for consistent design across pages.
  - Created specific skeleton components such as `PlayCardSkeleton`, `CreatePlaySkeleton`, `PlanViewSkeleton`, `PlaybookLibrarySkeleton`, `ScheduleSkeleton`, `PlayerDetailSkeleton`, and `StatisticsSkeleton` for various features and pages. These components provide tailored loading states for different layouts and functionalities. [[1]](diffhunk://#diff-e725552f4ffdaa8f3410d18bf707748877225edffe22ff183882e71a0ccdd866R1-R13) [[2]](diffhunk://#diff-58ae7eeb31a46c0397030244474d970177ccfaddf72ba58219416998f6ca3a2dR1-R55) [[3]](diffhunk://#diff-b6fb66271900c0b4a03a7675db0d66794a4b87d10fcca61dc0a29f199aca6462R1-R24) [[4]](diffhunk://#diff-20c046e918467bd0274b733e91ca2e24dd8122a745163f1decc054fe7b1bf5fcR1-R30) [[5]](diffhunk://#diff-ed2070c6ce930878ca47756d860f1a32035ce9873d2b2cea5740767c696d2e8aR1-R41) [[6]](diffhunk://#diff-c5cc8071ef79c1f6992e74df7fe5fa9715a8ca99111e193c434f73c749715a73R1-R37) [[7]](diffhunk://#diff-38e55f3c7d63d4c58124629dd75f7d2ccd6820e5e9ec4d6574c87e150b639e5dR1-R41)

### Integration of Skeleton Components into Pages:

* **Feature-Specific Skeletons**:
  - Incorporated skeleton components into pages such as `playbook-library`, `schedule`, and `statistics` to enhance the user experience during data fetching. For instance, `PlaybookLibrarySkeleton` is used in `playbook-library/page.tsx`, and `StatisticsSkeleton` is used in `statistics/page.tsx`. ([src/app/[teamId]/playbook-library/page.tsxR25](diffhunk://#diff-d0283809825abb9a9834a861a620b5ac98d2efd1d682e503173d727544e3c7a7R25), [src/app/[teamId]/schedule/page.tsxL20-R26](diffhunk://#diff-15b8d5c245eadb0edd6f4f995b6bbe74d0132ebc53ba363d5e63cece1847370dL20-R26), [src/app/[teamId]/statistics/page.tsxL26-R34](diffhunk://#diff-d9318a874880d1554f628975f52dd3cfb410d805faf89faf178d625fe54f6bf1L26-R34))

These changes collectively improve the application's responsiveness and visual feedback during loading states, while maintaining a consistent design language across features.